### PR TITLE
Fix jumpiness in the config page

### DIFF
--- a/utils/darkLightContainer.tsx
+++ b/utils/darkLightContainer.tsx
@@ -1,39 +1,25 @@
-import React, { use, useEffect, useState } from "react";
-import { PaletteMode, ThemeProvider, createTheme } from '@mui/material';
-import { useTheme } from 'next-themes';
-import CssBaseline from '@mui/material/CssBaseline';
+import React from "react";
+import { PaletteMode } from '@mui/material'
+import {  ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider as NextThemeProvider, useTheme } from 'next-themes';
 
 export const DarkLightContainer = ({ children }) => {
     const { resolvedTheme } = useTheme();
-    const [theme, setTheme] = useState('dark');
-    useEffect(() => {
-        let mounted = true;
-        if (resolvedTheme === 'system') {
-            if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                setTheme('dark');
-            }
-            else {
-                setTheme('light');
-            }
-        } else {
-            setTheme(resolvedTheme);
-        }
 
-        return () => {
-            mounted = false;
-        };
-    }, [resolvedTheme]);
+    // Default to 'light' mode if resolvedTheme is undefined
+    const mode: PaletteMode = resolvedTheme === 'dark' ? 'dark' : 'light';
 
     const muiTheme = createTheme({
         palette: {
-            mode: theme as PaletteMode,
-        }
+            mode: mode,
+        },
     });
-
+    
     return (
-        <ThemeProvider theme={muiTheme}>
-            <CssBaseline />
-            {children}
-        </ThemeProvider>
+        <NextThemeProvider>
+            <ThemeProvider theme={muiTheme}>
+                {children}
+            </ThemeProvider>
+        </NextThemeProvider>
     )
 }


### PR DESCRIPTION
Fixes #13 (reopened a reverted PR that causes client-side error)
* Fix undefined theme at the start of client rendering (to avoid client-side error). This still introduces a bit of jumpiness in the dark mode but it is very subtle. The light mode will have not jumpiness at all.