### PR TITLE
Add client/server selector to `DownloadsComponent`

### DIFF
--- a/components/DownloadsComponent.tsx
+++ b/components/DownloadsComponent.tsx
@@ -1,9 +1,9 @@
 "use client"
 import React, { useState, useEffect, useMemo } from 'react';
-import { Box, CircularProgress} from '@mui/material';
+import { Box, CircularProgress } from '@mui/material';
 import fetchFilteredReleases from "../utils/fetchReleases";
-import { FilteredRelease, ArchEnums, OSEnums, SemverRegex } from '../utils/types';
-import {OperatingSystems, Architectures, Versions} from './Filters';
+import { FilteredRelease, ArchEnums, OSEnums, SemverRegex, BinaryTypeEnums } from '../utils/types';
+import { OperatingSystems, Architectures, Versions, BinaryTypes } from './Filters';
 import ReleasesTable from './ReleasesTable';
 import { useTheme } from '@mui/material/styles';
 import { parseEnum } from '@/utils/utils';
@@ -12,6 +12,7 @@ interface optionMatrix {
     arch: ArchEnums | ""
     os: OSEnums | ""
     version: string
+    binaryType: BinaryTypeEnums | ""
 }
 
 const downloadTableHeader = [
@@ -26,11 +27,12 @@ const DownloadsComponent: React.FC = () => {
     const [originalData, setOriginalData] = useState<FilteredRelease[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
-    const [versions, setVersions] = useState([])
+    const [versions, setVersions] = useState<string[]>([])
     const [selectedOptions, setSelectedOptions] = useState<optionMatrix>({
         arch: ArchEnums.X86_64,
         os: OSEnums.Linux,
-        version: ""
+        version: "",
+        binaryType: BinaryTypeEnums.Client,
     });
     
     const theme = useTheme();
@@ -59,6 +61,18 @@ const DownloadsComponent: React.FC = () => {
         }
     };
 
+    const handleBinaryType = (
+        event: React.MouseEvent<HTMLElement, MouseEvent>,
+        newBinaryType: string | null,
+    ) => {
+        if (newBinaryType !== selectedOptions.binaryType) {
+            setSelectedOptions(prevOptions => ({
+                ...prevOptions,
+                binaryType: newBinaryType as BinaryTypeEnums || ''
+            }));
+        }
+    };
+
     useEffect(() => {
         const fetchAssets = async () => {
             setLoading(true);
@@ -79,16 +93,19 @@ const DownloadsComponent: React.FC = () => {
         const qVersion = params.get("version")
         const qArch = parseEnum(params.get("arch"), ArchEnums)
         const qOS = parseEnum(params.get("os"), OSEnums)
+        const qBinaryType = parseEnum(params.get("binaryType"), BinaryTypeEnums)
         const queryMatrix: optionMatrix = {
             arch: qArch || '',
             os: qOS || '',
-            version: SemverRegex.test(qVersion) ? qVersion : ""
+            version: SemverRegex.test(qVersion) ? qVersion : "",
+            binaryType: qBinaryType || BinaryTypeEnums.Client,
         }
         setSelectedOptions((prev) => (
             {
                 arch: queryMatrix.arch ? queryMatrix.arch : prev.arch,
                 os: queryMatrix.os ? queryMatrix.os : prev.os,
                 version: queryMatrix.version ? queryMatrix.version : prev.version,
+                binaryType: queryMatrix.binaryType ? queryMatrix.binaryType : prev.binaryType,
             }
         ))
 
@@ -107,8 +124,9 @@ const DownloadsComponent: React.FC = () => {
         const filteredAssets = filteredByVersion.assets.filter(asset => {
             const osMatch = !selectedOptions.os || asset.osInternal.toLowerCase().includes(selectedOptions.os.toLowerCase());
             const archMatch = !selectedArch || asset.architecture === selectedArch;
+            const binaryTypeMatch = !selectedOptions.binaryType || asset.binaryType === selectedOptions.binaryType;
       
-            return osMatch && archMatch;
+            return osMatch && archMatch && binaryTypeMatch;
           })
           .sort((a, b) => {
             // Sort by OS
@@ -151,6 +169,7 @@ const DownloadsComponent: React.FC = () => {
                         },
                     }}>
                         <Versions handleChange={(e) => {setSelectedOptions((prev) => ({...prev, version: e.target.value}))}} versions={versions} value={selectedOptions.version}/>
+                        <BinaryTypes handle={handleBinaryType} defaultBinaryType={selectedOptions.binaryType} />
                         <OperatingSystems handle={handleOs} defaultOs={selectedOptions.os} defaultArch={selectedOptions.arch} data={Object.values(OSEnums)} />
                         <Architectures handle={handleArch} defaultArch={selectedOptions.arch} defaultOs={selectedOptions.os} archs={Object.values(ArchEnums)} />
                     </Box>

--- a/components/DownloadsComponent.tsx
+++ b/components/DownloadsComponent.tsx
@@ -20,7 +20,7 @@ const downloadTableHeader = [
     "Architecture",
     "OS",
     "File",
-    "Variant"
+    "Type"
 ]
 
 const DownloadsComponent: React.FC = () => {
@@ -29,10 +29,10 @@ const DownloadsComponent: React.FC = () => {
     const [error, setError] = useState<string | null>(null);
     const [versions, setVersions] = useState<string[]>([])
     const [selectedOptions, setSelectedOptions] = useState<optionMatrix>({
-        arch: ArchEnums.X86_64,
-        os: OSEnums.Linux,
+        arch: "",
+        os: "",
         version: "",
-        binaryType: BinaryTypeEnums.Client,
+        binaryType: "",
     });
     
     const theme = useTheme();
@@ -88,30 +88,30 @@ const DownloadsComponent: React.FC = () => {
                 setLoading(false);
             }
         };
-
-        const params = new URLSearchParams(window?.location.search)
-        const qVersion = params.get("version")
-        const qArch = parseEnum(params.get("arch"), ArchEnums)
-        const qOS = parseEnum(params.get("os"), OSEnums)
-        const qBinaryType = parseEnum(params.get("binaryType"), BinaryTypeEnums)
-        const queryMatrix: optionMatrix = {
-            arch: qArch || '',
-            os: qOS || '',
-            version: SemverRegex.test(qVersion) ? qVersion : "",
-            binaryType: qBinaryType || BinaryTypeEnums.Client,
-        }
-        setSelectedOptions((prev) => (
-            {
-                arch: queryMatrix.arch ? queryMatrix.arch : prev.arch,
-                os: queryMatrix.os ? queryMatrix.os : prev.os,
-                version: queryMatrix.version ? queryMatrix.version : prev.version,
-                binaryType: queryMatrix.binaryType ? queryMatrix.binaryType : prev.binaryType,
-            }
-        ))
-
         fetchAssets();
     }, []);
-    
+
+    useEffect(() => {
+      const params = new URLSearchParams(window?.location.search)
+      const qVersion = params.get("version")
+      const qArch = parseEnum(params.get("arch"), ArchEnums)
+      const qOS = parseEnum(params.get("os"), OSEnums)
+      const qBinaryType = parseEnum(params.get("binaryType"), BinaryTypeEnums)
+      const queryMatrix: optionMatrix = {
+        arch: qArch || '',
+        os: qOS || '',
+        version: SemverRegex.test(qVersion || "") && qVersion ? qVersion : "",
+        binaryType: qBinaryType || "",
+      }
+      setSelectedOptions((prev) => (
+        {
+          arch: queryMatrix.arch ? queryMatrix.arch : prev.arch,
+          os: queryMatrix.os ? queryMatrix.os : prev.os,
+          version: queryMatrix.version ? queryMatrix.version : prev.version,
+          binaryType: queryMatrix.binaryType ? queryMatrix.binaryType : prev.binaryType,
+        }
+      ))
+    }, []);
 
     const filteredData = useMemo(() => {
         const selectedArch = selectedOptions.arch;

--- a/components/Filters.tsx
+++ b/components/Filters.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, ToggleButton, ToggleButtonGroup, Typography, Select, MenuItem, SelectChangeEvent } from '@mui/material';
-import { compatibilityRules, ArchitecturesProps, OperatingSystemsProps, VersionProps } from '../utils/types';
+import { compatibilityRules, ArchitecturesProps, OperatingSystemsProps, VersionProps, BinaryTypesProps, BinaryTypeEnums } from '../utils/types';
 
 
 export const Versions:React.FC<VersionProps> = ({handleChange, value, versions}) => {
@@ -90,3 +90,26 @@ export const OperatingSystems:React.FC<OperatingSystemsProps> = ({handle, defaul
   )
 }
 
+export const BinaryTypes: React.FC<BinaryTypesProps> = ({handle, defaultBinaryType}) => {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", margin: "0 10px 0 0" }}>
+      <Typography variant="overline" display="block" gutterBottom>
+        Binary Type
+      </Typography>
+      <ToggleButtonGroup
+        color="primary"
+        value={defaultBinaryType}
+        exclusive
+        aria-label="Binary Type"
+        onChange={handle}
+        size="small"
+      >
+        {Object.values(BinaryTypeEnums).map((type) => (
+          <ToggleButton key={type} value={type}>
+            {type}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+    </Box>
+  )
+}

--- a/components/ReleasesTable.tsx
+++ b/components/ReleasesTable.tsx
@@ -3,10 +3,13 @@ import {
     Typography, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Link, Tooltip,
     Chip} 
     from '@mui/material';
-import { ReleasesTableProps } from '../utils/types';
+import {PackageType, ReleasesTableProps} from '../utils/types';
 
-const OSDFNote = "This package is compatible with Open Science Data Federation (OSDF). Download this package if you plan to use it in OSDF. Note that you need to install Pelican package first."
-const ServerNote = "This package includes Pelican origin/cache server dependencies. Download this package if you want to serve a Pelican origin or cache server. Note that you need to install Pelican package first."
+const PackageNotes = {
+    OSDF: "This package is compatible with Open Science Data Federation (OSDF). Download this package if you plan to use it in OSDF. Note that you need to install Pelican package first.",
+    Server: "This package includes Pelican origin/cache server dependencies. Download this package if you want to serve a Pelican origin or cache server. Note that you need to install Pelican package first.",
+    Client: "This package includes Pelican client dependencies. Download this package if you want to use the Pelican client."
+}
 
 const ReleasesTable: React.FC<ReleasesTableProps> = ({ release , rowNames }) => {
     return(
@@ -31,13 +34,7 @@ const ReleasesTable: React.FC<ReleasesTableProps> = ({ release , rowNames }) => 
                         </Link>
                     </TableCell>
                     <TableCell>
-                        {
-                            asset.specialPackage && (
-                                <Tooltip title={asset.specialPackage === "OSDF" ? OSDFNote : ServerNote} placement='right' arrow>
-                                    <Chip label={asset.specialPackage} color="primary" variant="outlined" onClick={() => {window.location.hash = "#install-osdf-or-server-package"}}/>
-                                </Tooltip>
-                            )
-                        }
+                        <PackageTypeChip type={asset.specialPackage} />
                     </TableCell>
                     </TableRow>
                 ))}
@@ -45,6 +42,14 @@ const ReleasesTable: React.FC<ReleasesTableProps> = ({ release , rowNames }) => 
         </Table>
         </TableContainer>
     );
+}
+
+const PackageTypeChip: React.FC<{type: PackageType}> = ({type}) => {
+  return (
+    <Tooltip title={PackageNotes[type]} placement='right' arrow>
+      <Chip label={type} color="primary" variant="outlined"/>
+    </Tooltip>
+  )
 }
 
 export default ReleasesTable;

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,7 +246,6 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -287,7 +286,6 @@
       "version": "11.14.1",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -964,7 +962,6 @@
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.4.tgz",
       "integrity": "sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.4",
@@ -2235,6 +2232,18 @@
         }
       }
     },
+    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      }
+    },
     "node_modules/@swagger-api/apidom-reference": {
       "version": "1.0.0-beta.50",
       "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.0.0-beta.50.tgz",
@@ -2723,7 +2732,6 @@
       "version": "18.2.29",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.29.tgz",
       "integrity": "sha512-Z+ZrIRocWtdD70j45izShRwDuiB4JZqDegqMFW/I8aG5DxxLKOzVNoq62UIO82v9bdgi+DO1jvsb9sTEZUSm+Q==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2806,7 +2814,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3147,7 +3154,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -3382,7 +3388,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3792,7 +3797,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5107,7 +5111,6 @@
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
       "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6914,7 +6917,6 @@
       "version": "15.5.4",
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.4.tgz",
       "integrity": "sha512-xH4Yjhb82sFYQfY3vbkJfgSDgXvBB6a8xPs9i35k6oZJRoQRihZH+4s9Yo2qsWpzBmZ3lPXaJ2KPXLfkvW4LnA==",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.4",
         "@swc/helpers": "0.5.15",
@@ -7654,7 +7656,6 @@
       "version": "0.30.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -7699,7 +7700,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7744,7 +7744,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -7961,8 +7960,7 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "peer": true
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/redux-immutable": {
       "version": "4.0.0",
@@ -9164,7 +9162,6 @@
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.15.0.tgz",
       "integrity": "sha512-kLdkY6iV3dYbtPwS9KXU7mjfmDm25f5m0IPNFnaXO7TBPcvbUOY72PYXSuSqDzwp+vlH/d7MXpHlKO/x+QoLXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@shikijs/core": "3.15.0",
         "@shikijs/engine-javascript": "3.15.0",
@@ -9501,7 +9498,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9569,6 +9565,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+    },
+    "node_modules/tree-sitter": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      }
     },
     "node_modules/tree-sitter-json": {
       "version": "0.24.8",
@@ -9672,7 +9680,6 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/utils/fetchReleases.tsx
+++ b/utils/fetchReleases.tsx
@@ -1,5 +1,5 @@
 import semver from 'semver'
-import { Release, FilteredRelease, packageDisplayedOS, OSEnums, archMapping } from './types';
+import { Release, FilteredRelease, packageDisplayedOS, OSEnums, archMapping, BinaryTypeEnums } from './types';
 import {getAllGithub} from "@/utils/utils";
 
 function getDisplayedOS(filename: string) {
@@ -61,7 +61,10 @@ async function fetchFilteredReleases(): Promise<FilteredRelease[]> {
           osInternal: asset.name.includes('checksums.txt') ? '' : asset.name.includes('Darwin') ? 'macOS' : Object.values(OSEnums).find(os => asset.name.includes(os)) || 'Linux',
           osDisplayed: getDisplayedOS(asset.name),
           architecture: getArchitecture(asset.name),
-          specialPackage: asset.name.includes('-server-') ? "Server" : asset.name.includes('-osdf-') ? "OSDF" : ""
+          specialPackage: asset.name.includes('-osdf-') ? "OSDF"
+            : (semver.lt(release.tag_name, 'v7.26.0') && /^pelican-server[_-]/.test(asset.name)) ? "Server"
+            : "",
+          binaryType: asset.name.startsWith('pelican-server') ? BinaryTypeEnums.Server : BinaryTypeEnums.Client
         };
       })
     });

--- a/utils/fetchReleases.tsx
+++ b/utils/fetchReleases.tsx
@@ -63,7 +63,7 @@ async function fetchFilteredReleases(): Promise<FilteredRelease[]> {
           architecture: getArchitecture(asset.name),
           specialPackage: asset.name.includes('-osdf-') ? "OSDF"
             : (semver.lt(release.tag_name, 'v7.26.0') && /^pelican-server[_-]/.test(asset.name)) ? "Server"
-            : "",
+            : "Client",
           binaryType: asset.name.startsWith('pelican-server') ? BinaryTypeEnums.Server : BinaryTypeEnums.Client
         };
       })

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -20,6 +20,11 @@ export interface OperatingSystemsProps {
     data: Array<string>;
   }
 
+export interface BinaryTypesProps {
+    handle: (event: React.MouseEvent<HTMLElement, MouseEvent>, newBinaryType: string | null) => void;
+    defaultBinaryType: string;
+  }
+
 export interface Asset {
 name: string;
 browser_download_url: string;
@@ -48,6 +53,7 @@ specialPackage: "OSDF" | "Server" | ""; // Special package for OSDF/Pelican serv
 osInternal: string;
 osDisplayed: string;
 architecture: string;
+binaryType: BinaryTypeEnums | "";
 packageInfo?: string;
 packageDescription?: string;
 }
@@ -97,6 +103,11 @@ export enum ArchEnums {
   X86_64 = "X86_64",
   ARM64 = "ARM64",
   PowerPC = "PowerPC"
+}
+
+export enum BinaryTypeEnums {
+  Client = "Client",
+  Server = "Server"
 }
 
 export const archMapping = {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -49,7 +49,7 @@ name: string;
 downloadUrl: string;
 id: number;
 assetVersion: string; // Version of the release this asset belongs to
-specialPackage: "OSDF" | "Server" | ""; // Special package for OSDF/Pelican server
+specialPackage: PackageType; // Special package for OSDF/Pelican server
 osInternal: string;
 osDisplayed: string;
 architecture: string;
@@ -57,6 +57,8 @@ binaryType: BinaryTypeEnums | "";
 packageInfo?: string;
 packageDescription?: string;
 }
+
+export type PackageType = "OSDF" | "Server" | "Client"
 
 export interface ReleasesTableProps {
     rowNames: Array<string>;


### PR DESCRIPTION
The Pelican binaries are now split into separate client/server binaries, so we have a bit more work to do guiding users to select the correct binary.

This is my YOLO AI attempt to update this component myself. I'm 100% okay if this implementation sucks and someone wants to redesign it, but merging some solution to this problem is probably a `7.26` release blocker.

Here's a screenshot demonstrating the new clickable:
<img width="867" height="459" alt="Screenshot 2026-04-27 at 14 42 47" src="https://github.com/user-attachments/assets/565bd77b-77ae-41f5-aae2-08dc1924a18f" />
